### PR TITLE
User Rating Creation Sad Path Testing

### DIFF
--- a/app/controllers/profile/ratings_controller.rb
+++ b/app/controllers/profile/ratings_controller.rb
@@ -1,4 +1,6 @@
 class Profile::RatingsController < ApplicationController
+  before_action :require_default_user
+
   def new
     @order = Order.find(params[:order_id])
     @order_item = OrderItem.find(params[:order_item_id])
@@ -8,19 +10,24 @@ class Profile::RatingsController < ApplicationController
 
   def create
     @item = OrderItem.find(params[:order_item_id]).item
-    @rating = Rating.create(item: @item,
+
+    if @item.ratings.count < 1 || @item.ratings.count == nil
+      @rating = Rating.create(item: @item,
                             user: current_user,
                             title: rating_params[:title],
                             description: rating_params[:description],
                             score: rating_params[:score],
                             active: true)
-
-    if @rating.save
-      redirect_to profile_order_path(params[:order_id])
-      flash[:success] = "Your rating was created successfully."
+      if @rating.save
+        redirect_to profile_order_path(params[:order_id])
+        flash[:success] = "Your rating was created successfully."
+      else
+        flash[:error] = "Your rating has not been created."
+        render :new
+      end
     else
-      flash[:error] = "Your rating has not been created."
-      render :new
+      flash[:error] = "You have already rated this item."
+      redirect_to profile_order_path(params[:order_id])
     end
   end
 
@@ -28,5 +35,9 @@ class Profile::RatingsController < ApplicationController
 
   def rating_params
     params.require(:rating).permit(:title, :description, :score)
+  end
+
+  def require_default_user
+    render file: 'errors/not_found', status: 404 unless current_user && current_user.default?
   end
 end

--- a/app/views/profile/orders/_order_item.html.erb
+++ b/app/views/profile/orders/_order_item.html.erb
@@ -14,7 +14,7 @@
       <h5 class="item-rating-link"><%= link_to "Rate this Item", profile_order_new_order_item_rating_path(@order, oitem) %></h5>
     <%end %>
 
-    <% if oitem.item.ratings.count == 1 %>
+    <% if oitem.item.ratings.count >= 1 %>
       <div class='item_rating'>
         <h2>Item Rating:</h2>
         <p>Rating Title: <%= oitem.item.ratings[0].title %></p>

--- a/spec/features/user/profile_orders_ratings_spec.rb
+++ b/spec/features/user/profile_orders_ratings_spec.rb
@@ -2,6 +2,34 @@ require 'rails_helper'
 
 include ActionView::Helpers::NumberHelper
 
+describe 'as a visitor' do
+  describe 'on the profile orders page' do
+    it 'can create a new rating for an item' do
+      user = create(:user)
+      merchant_1 = create(:merchant)
+      item_1 = create(:item, user: merchant_1)
+      yesterday = 1.day.ago
+      order_1 = create(:completed_order, user: user, created_at: yesterday)
+      oi_1 = create(:fulfilled_order_item, order: order_1, item: item_1,
+                    price: 1, quantity: 3, created_at: yesterday,
+                    updated_at: yesterday)
+      rating_1 = Rating.create(item_id: item_1, user: user,
+                                title: "Terrible Product",
+                                description: "Worst thing I ever bought!",
+                                score: 1, active: true)
+
+      visit profile_order_path(order_1)
+
+      within "#oitem-#{oi_1.id}" do
+        click_on "Rate this Item"
+      end
+
+      expect(page.status_code).to eq(404)
+      end
+
+  end
+end
+
 describe 'as a registered user' do
   describe 'on the profile orders page' do
     before :each do
@@ -17,17 +45,36 @@ describe 'as a registered user' do
       @yesterday = 1.day.ago
 
       @order_1 = create(:completed_order, user: @user, created_at: @yesterday)
-      @oi_1 = create(:fulfilled_order_item, order: @order_1, item: @item_1, price: 1, quantity: 3, created_at: @yesterday, updated_at: @yesterday)
-      @oi_2 = create(:fulfilled_order_item, order: @order_1, item: @item_2, price: 2, quantity: 5, created_at: @yesterday, updated_at: 2.hours.ago)
+      @oi_1 = create(:fulfilled_order_item, order: @order_1, item: @item_1,
+                      price: 1, quantity: 3, created_at: @yesterday,
+                      updated_at: @yesterday)
+      @oi_2 = create(:fulfilled_order_item, order: @order_1, item: @item_2,
+                     price: 2, quantity: 5, created_at: @yesterday,
+                     updated_at: 2.hours.ago)
 
       @order_2 = create(:order, user: @user, created_at: @yesterday)
-      @oi_3 = create(:order_item, order: @order_2, item: @item_1, price: 1, quantity: 3, created_at: @yesterday, updated_at: @yesterday)
-      @oi_4 = create(:fulfilled_order_item, order: @order_2, item: @item_2, price: 2, quantity: 5, created_at: @yesterday, updated_at: 2.hours.ago)
+      @oi_3 = create(:order_item, order: @order_2, item: @item_1, price: 1,
+                     quantity: 3, created_at: @yesterday, updated_at: @yesterday)
+      @oi_4 = create(:fulfilled_order_item, order: @order_2, item: @item_2,
+                     price: 2, quantity: 5, created_at: @yesterday,
+                     updated_at: 2.hours.ago)
 
-      @rating_1 = Rating.create(item_id: @item_1, user: @user, title: "Terrible Product", description: "Worst thing I ever bought!", score: 1, active: true)
-      @rating_2 = Rating.create(item_id: @item_1, user: @user, title: "Great Product", description: "Best thing I ever bought!", score: 5, active: true)
-      @rating_inactive = Rating.create(item_id: @item_1, title: "Terrible Product", description: "Worst thing I ever bought!", score: 1, active: false)
-      @rating_invalid = Rating.create(item_id: @item_1, title: "Terrible Product", description: "Worst thing I ever bought!", score: 7, active: true)
+      @rating_1 = Rating.create(item_id: @item_1, user: @user,
+                                title: "Terrible Product",
+                                description: "Worst thing I ever bought!",
+                                score: 1, active: true)
+      @rating_2 = Rating.create(item_id: @item_1, user: @user,
+                                title: "Great Product",
+                                description: "Best thing I ever bought!",
+                                score: 5, active: true)
+      @rating_inactive = Rating.create(item_id: @item_1,
+                                       title: "Terrible Product",
+                                       description: "Worst thing I ever bought!",
+                                       score: 1, active: false)
+      @rating_invalid = Rating.create(item_id: @item_1,
+                                      title: "Terrible Product",
+                                      description: "Worst thing I ever bought!",
+                                      score: 7, active: true)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
     end


### PR DESCRIPTION
Adds sad path testing & logic for a visitor to the site cannot leave a review, as well as, users cannot leave more than one review for an order_item.

Also cleans up some of the formatting in the profile_orders_rating test file to look better.

All tests are passing still.